### PR TITLE
Set Vazirmatn as the default font for the project

### DIFF
--- a/Front/src/index.css
+++ b/Front/src/index.css
@@ -1,9 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: 'Vazirmatn', sans-serif;
+@layer base {
+  html, body, div, p, h1, h2, h3, h4, h5, h6, span, a, li {
+    font-family: 'Vazirmatn', sans-serif !important;
+  }
 }

--- a/Front/src/index.css
+++ b/Front/src/index.css
@@ -1,7 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100..900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Vazirmatn', sans-serif;
 }


### PR DESCRIPTION
This PR integrates the Vazirmatn font into the project using Google Fonts. 
- Updates global styles to use Vazirmatn as the default font
- No functional changes, feel free to merge!